### PR TITLE
Feat/cop no command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### v0.1.0
 
 * Initial release.
+* Add cop Platanus/NoCommand

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-platanus (0.1.0)
-      rubocop
+      rubocop (>= 0.89.0)
 
 GEM
   remote: https://rubygems.org/

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,1 +1,6 @@
+# Write it!
 
+Platanus/NoCommand:
+  Description: "Prefer usage of `ActiveJob` instead of `PowerTypes::Command`"
+  Enabled: true
+  VersionAdded: "<<next>>"

--- a/lib/rubocop/cop/platanus/no_command.rb
+++ b/lib/rubocop/cop/platanus/no_command.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Platanus
+      # Usage of PowerTypes::Command is no longer recommended. Rails
+      # ApplicationJob should be used instead.
+      #
+      # @example
+      #
+      #   # bad
+      #   class ExecuteSomeAction < PowerTypes::Command.new(:foo, :bar)
+      #     def perform
+      #       # Command code goes here
+      #     end
+      #    end
+      #
+      #   # good
+      #   class GuestsCleanupJob < ApplicationJob
+      #     def perform
+      #       # Job code goes here
+      #     end
+      #   end
+      #
+      class NoCommand < Base
+        MSG = 'Use `ApplicationJob` instead of `PowerTypes::Command`.'
+
+        # @!method uses_powertypes_command?(node)
+        def_node_matcher :uses_powertypes_command?, <<~PATTERN
+          (class _ (send (const (const _ :PowerTypes) :Command) :new ...) _)
+        PATTERN
+
+        def on_class(node)
+          return unless uses_powertypes_command?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/platanus_cops.rb
+++ b/lib/rubocop/cop/platanus_cops.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'platanus/no_command'

--- a/rubocop-platanus.gemspec
+++ b/rubocop-platanus.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "rubocop", "~> 1.9"
-  spec.add_runtime_dependency 'rubocop'
+  spec.add_runtime_dependency 'rubocop', ">= 0.89.0"
 end

--- a/spec/rubocop/cop/platanus/no_command_spec.rb
+++ b/spec/rubocop/cop/platanus/no_command_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Platanus::NoCommand, :config do
+  it 'registers an offense when using `PowerTypes::Command`' do
+    expect_offense(<<~RUBY)
+      class MyCommand < PowerTypes::Command.new(:bar)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `ApplicationJob` instead of `PowerTypes::Command`.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when not using `PowerTypes::Command`' do
+    expect_no_offenses(<<~RUBY)
+      class MyCommand < ApplicationJob
+      end
+
+      class MyClass
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
# Contexto

En Platanus todo el tiempo estamos cambiando herramientas, mejorando nuestras prácticas, etc. Esto ocasiona que los proyectos más viejos no reflejen nuestras últimas decisiones respecto de x temas. Para mantener cierto orden en el código, estamos utilizando [Rubocop](https://github.com/rubocop/rubocop). Esta gema define cientos de reglas de estilo que nos permite escribir código similar/entendible. La idea es crear reglas custom para impulsar decisiones que tomemos desde calidad dev.

Hace un tiempo se decidió que dejaríamos de usar [comandos de power types](https://github.com/platanus/power-types#commands) para usar directamente jobs. Estaría bueno que existiera una regla custom de rubocop que nos dijera un mensaje tipo:

> Don't use commands! (Platanus/NoCommand)

en la definición

```rb
class SomeCommand < PowerTypes::Command.new(:foo, :bar)
  def perform
    # ...
  end
end
```

# Que se está haciendo

- Se agrega el cop Platanus/NoCommand y sus tests.
- Se agrega dependencia de versiones sobre rubocop para soportar la forma actual de escribir un cop custom

# Que revisar

- El mensaje y/o funcionamiento del cop