### PR TITLE
Feat/pundit in application controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Unreleased
+
+Features
+
+* Add cop Platanus/PunditInApplicationController
+
 ### v0.1.0
 
 * Initial release.

--- a/config/default.yml
+++ b/config/default.yml
@@ -4,3 +4,8 @@ Platanus/NoCommand:
   Description: "Prefer usage of `ActiveJob` instead of `PowerTypes::Command`"
   Enabled: true
   VersionAdded: "<<next>>"
+
+Platanus/PunditInApplicationController:
+  Description: "`Pundit` should be included only in the `Application Controller`"
+  Enabled: true
+  VersionAdded: "0.1.0"

--- a/lib/rubocop/cop/platanus/pundit_in_application_controller.rb
+++ b/lib/rubocop/cop/platanus/pundit_in_application_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Platanus
+      # Pundit should not be included in specific controllers. Prefer
+      # including it in the ApplicationController instead.
+      #
+      # @example
+      #   # bad
+      #   class ApplicationController < ActionController::Base
+      #   end
+      #
+      #   class FooController < ApplicationController
+      #     include Pundit
+      #   end
+      #
+      #   # bad
+      #   class ApplicationController < ActionController::Base
+      #   end
+      #
+      #   class FooController < ApplicationController
+      #     include Pundit::Authorization
+      #   end
+      #
+      #   # good
+      #   class ApplicationController < ActionController::Base
+      #     include Pundit
+      #   end
+      #
+      #   class FooController < ApplicationController
+      #   end
+      #
+      #   # good
+      #   class ApplicationController < ActionController::Base
+      #     include Pundit::Authorization
+      #   end
+      #
+      #   class FooController < ApplicationController
+      #   end
+      #
+      class PunditInApplicationController < Base
+        MSG = '`Pundit` should be included only in the `ApplicationController`.'
+
+        def_node_matcher :get_include_pundit_node, <<~PATTERN
+          (class _ _ `$(
+            send
+            nil?
+            :include
+            (const {nil? | (const _ :Pundit)} {:Pundit | :Authorization})
+          ))
+        PATTERN
+
+        def_node_matcher :application_controller?, <<~PATTERN
+          (class (const nil? :ApplicationController) `(const (const nil? :ActionController) :Base) ...)
+        PATTERN
+
+        def on_class(node)
+          pundit_include_node = get_include_pundit_node(node)
+          return unless pundit_include_node && !application_controller?(node)
+
+          add_offense(pundit_include_node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/platanus_cops.rb
+++ b/lib/rubocop/cop/platanus_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'platanus/no_command'
+require_relative 'platanus/pundit_in_application_controller'

--- a/spec/rubocop/cop/platanus/pundit_in_application_controller_spec.rb
+++ b/spec/rubocop/cop/platanus/pundit_in_application_controller_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Platanus::PunditInApplicationController, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when including `Pundit` out of `ApplicationController`' do
+    expect_offense <<~RUBY
+      class FooController < BarController::Base
+        include Baz
+        include Pundit::Authorization
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Pundit` should be included only in the `ApplicationController`.
+        include Qux
+
+        def main
+        end
+      end
+    RUBY
+
+    expect_offense <<~RUBY
+      class FooController < BarController::Base
+        include Baz
+        include Pundit
+        ^^^^^^^^^^^^^^ `Pundit` should be included only in the `ApplicationController`.
+        include Qux
+
+        def main
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register when including `Pundit` in `ApplicationController`' do
+    expect_no_offenses <<~RUBY
+      class ApplicationController < ActionController::Base
+        include Baz
+        include Pundit::Authorization
+        include Qux
+
+        def main
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register when not including `Pundit`' do
+    expect_no_offenses <<~RUBY
+      class FooController < BarController::Base
+        include Baz
+        include Qux
+
+        def main
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
# Contexto

En Platanus todo el tiempo estamos cambiando herramientas, mejorando nuestras prácticas, etc. Esto ocasiona que los proyectos más viejos no reflejen nuestras últimas decisiones respecto de x temas. Para mantener cierto orden en el código, estamos utilizando [Rubocop](https://github.com/rubocop/rubocop). Esta gema define cientos de reglas de estilo que nos permite escribir código similar/entendible. La idea es crear reglas custom para impulsar decisiones que tomemos desde calidad dev.

A veces pasa que se incluye Pundit dentro de los controllers base de las APIs (incluso a veces dentro de un controller específico) y debería ser incluido a un nivel más global. En el ApplicationController.

# Que se esta haciendo

- Se crea el cop `Platanus/PunditInApplicationController` que muestra un warning cuando se agrega `include Pundit` o `include Pundit::Authorization` en un controlador que no sea el `ApplicationController`

![image](https://user-images.githubusercontent.com/30664457/168856377-da63761f-999b-4c67-963b-cb1f5d69f7c6.png)

![image](https://user-images.githubusercontent.com/30664457/168856330-7242bd31-0b37-40e9-a9af-6a6e65842cfc.png)
