### PR TITLE
Feat/no render json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Features
 
+* Add cop Platanus/NoRenderJson
 * Add cop Platanus/PunditInApplicationController
 
 ### v0.1.0

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,11 @@ Platanus/NoCommand:
   Enabled: true
   VersionAdded: "<<next>>"
 
+Platanus/NoRenderJson:
+  Description: "Prefer usage of `respond_with` instead of `render json:` to take advantage of `ApiResponder` and `serializers`"
+  Enabled: true
+  VersionAdded: "<<next>>"
+
 Platanus/PunditInApplicationController:
   Description: "`Pundit` should be included only in the `Application Controller`"
   Enabled: true

--- a/lib/rubocop/cop/platanus/no_render_json.rb
+++ b/lib/rubocop/cop/platanus/no_render_json.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Platanus
+      # `render json:` shouldn't be used in controllers because it'll skip
+      #  the use of ApiResponder and serializers. Use `respond_with` instead.
+      #
+      # @example
+      #
+      #   # bad
+      #   render json: { data: @foo }
+      #
+      #   # bad
+      #   class Api::Internal::ResourcesController < Api::Internal::BaseController
+      #     def show
+      #       authorization_url = google_srv.generate_authorization_url
+      #       respond_with({ authorization_url: authorization_url })
+      #     end
+      #   end
+      #
+      #   # bad
+      #   class Api::Internal::ResourcesController < Api::Internal::BaseController
+      #     def show
+      #       hash_response = { data: @foo }
+      #       respond_with hash_response
+      #     end
+      #   end
+      #
+      #   # good
+      #   respond_with @foo
+      #
+      #   # good
+      #   # values/resource.rb
+      #   class Resource
+      #     include ActiveModel::Serialization
+      #
+      #     attr_accessor :id, :name
+      #
+      #     def initialize(id, name)
+      #       @id = id
+      #       @name = name
+      #     end
+      #   end
+      #
+      #   # serializers/resource_serializer.rb
+      #   class Api::Internal::ResourceSerializer < ActiveModel::Serializer
+      #     type :resource
+      #     attributes(
+      #       :id,
+      #       :name
+      #     )
+      #   end
+      #
+      #   # controllers/api/internal_resources/resources_controller.rb
+      #   class Api::Internal::ResourcesController < Api::Internal::BaseController
+      #     def show
+      #       respond_with(Resource.new(blog.id, blog.title))
+      #     end
+      #   end
+      #
+      class NoRenderJson < Base
+        RENDER_JSON_MSG = 'Use `respond_with` instead of `render json:`.'
+        RENDER_HASH_MSG =
+          'Don\'t use `respond_with` with a hash. Use a value and serializer instead.'
+
+        RESTRICT_ON_SEND = %i[render respond_with].freeze
+
+        # Matches if render is called with json
+        def_node_matcher :render_json?, <<~PATTERN
+          (send nil? :render (hash (pair (sym :json) ...) ...))
+        PATTERN
+
+        # Captures the argument of respond_with
+        def_node_matcher :respond_with, <<~PATTERN
+          (send nil? :respond_with $_)
+        PATTERN
+
+        # Matches if node is hash
+        def_node_matcher :is_hash?, '(hash ...)'
+
+        # Captures the variable named of a used variable
+        def_node_matcher :var_name, '(lvar $_)'
+
+        def on_send(node)
+          if render_json?(node)
+            add_offense(node, message: RENDER_JSON_MSG)
+          elsif respond_with_hash?(node)
+            add_offense(node, message: RENDER_HASH_MSG)
+          end
+        end
+
+        # Determines if the node corresponds to a call of respond_with
+        # with a hash as it's argument.
+        def respond_with_hash?(node)
+          hash_node = respond_with(node)
+          return true if is_hash?(hash_node)
+
+          return false unless hash_node.variable?
+
+          var_name = var_name(hash_node)
+          return false if var_name.nil?
+
+          var_is_hash?(node, var_name)
+        end
+
+        # Determines if a variable name corresponds to a hash within it's
+        # most immediate scope.
+        def var_is_hash?(node, var_name)
+          scope = node.parent
+          return false unless scope
+
+          pattern = "`(lvasgn :#{var_name} (hash ...))"
+          matcher = RuboCop::AST::NodePattern.new(pattern)
+
+          matcher.match(scope)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/platanus_cops.rb
+++ b/lib/rubocop/cop/platanus_cops.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require_relative 'platanus/no_command'
+require_relative 'platanus/no_render_json'
 require_relative 'platanus/pundit_in_application_controller'

--- a/spec/rubocop/cop/platanus/no_render_json_spec.rb
+++ b/spec/rubocop/cop/platanus/no_render_json_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Platanus::NoRenderJson, :config do
+  let(:config) { RuboCop::Config.new }
+  it 'registers an offense when using `render json:`' do
+    expect_offense <<~RUBY
+      render json: { data: @foo, message: 'bar' }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `respond_with` instead of `render json:`.
+    RUBY
+  end
+
+  it 'registers an offense when using `respond_with` with a hash' do
+    expect_offense <<~RUBY
+      respond_with({ data: @foo, message: 'bar' })
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don\'t use `respond_with` with a hash. Use a value and serializer instead.
+    RUBY
+  end
+
+  it 'registers an offense when using `respond_with` with a multiline hash' do
+    expect_offense <<~RUBY
+      respond_with({
+      ^^^^^^^^^^^^^^ Don\'t use `respond_with` with a hash. Use a value and serializer instead.
+        data: @foo,
+        message: "bar"
+      })
+    RUBY
+  end
+
+  it 'registers an offense when using `respond_with` with a hash from variable' do
+    expect_offense <<~RUBY
+      my_hash = { data: @foo, message: "bar" }
+      respond_with my_hash
+      ^^^^^^^^^^^^^^^^^^^^ Don\'t use `respond_with` with a hash. Use a value and serializer instead.
+    RUBY
+  end
+
+  it 'does not register an offense when using `respond_with` with a record' do
+    expect_no_offenses <<~RUBY
+      respond_with @foo
+    RUBY
+  end
+
+  it 'does not register an offense when using `respond_with` with a record from a variable' do
+    expect_no_offenses <<~RUBY
+      my_foo = @foo
+      respond_with my_foo
+    RUBY
+  end
+
+  it 'does not register an offense when using `respond_with` with a value' do
+    expect_no_offenses <<~RUBY
+      respond_with(Resource.new(blog.id, blog.title))
+    RUBY
+  end
+
+  it 'does not register an offense when using `respond_with` with a value from a variable' do
+    expect_no_offenses <<~RUBY
+      my_resource = Resource.new(blog.id, blog.title)
+      respond_with(my_resource)
+    RUBY
+  end
+end


### PR DESCRIPTION
# Contexto

En Platanus todo el tiempo estamos cambiando herramientas, mejorando nuestras prácticas, etc. Esto ocasiona que los proyectos más viejos no reflejen nuestras últimas decisiones respecto de x temas. Para mantener cierto orden en el código, estamos utilizando [Rubocop](https://github.com/rubocop/rubocop). Esta gema define cientos de reglas de estilo que nos permite escribir código similar/entendible. La idea es crear reglas custom para impulsar decisiones que tomemos desde calidad dev.

En las APIs de Platanus por ahí se usa en los controllers `render json: {}`. Esto no es buena práctica porque al usar render json nos saltamos el uso de [ApiResponder](https://github.com/platanus/power_api#the-apiresponder) y los serializers. La consecuencia de esto es que si se cambia el adapter, el formato de la respuesta no variará en endpoints que usen render json.

De ser posible, también debería desalentarse el uso de `respond_with { some: "hash" }` porque, aunque funciona, tiene el mismo problema. En estos casos deberían usarse values y, a esos values, hacerles un serializer.

# Que se esta haciendo

Se crea una regla que muestra un warning cuando se usa `render json:` o se usa `respond_with` con un hash.

![image](https://user-images.githubusercontent.com/30664457/168909016-970ea733-b152-4cd5-9d8d-b5928c19b586.png)
![image](https://user-images.githubusercontent.com/30664457/168909050-be05dcc2-771a-4c0e-9a9b-f350a9a2651a.png)
![image](https://user-images.githubusercontent.com/30664457/168909194-8e49f6da-cef2-4ab2-ac38-c9d8bd19a3be.png)
![image](https://user-images.githubusercontent.com/30664457/168909217-509970fc-1c88-4571-b9f7-364a9fe35e4a.png)
![image](https://user-images.githubusercontent.com/30664457/169570589-4ba6add6-e0e5-4146-9414-0ef24f4bb6ea.png)
![image](https://user-images.githubusercontent.com/30664457/169570701-6392423f-3190-4ed8-a81d-2eb2d4050cb6.png)

