### PR TITLE
Feat/no enumerize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Features
 
+* Add cop Platanus/NoEnumerize
 * Add cop Platanus/NoRenderJson
 * Add cop Platanus/PunditInApplicationController
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,14 @@ Platanus/NoCommand:
   Enabled: true
   VersionAdded: "<<next>>"
 
+Platanus/NoEnumerize:
+  Description: "Prefer usage of Rails `enum` instead of `Enumerize`"
+  Enabled: true
+  SafeAutoCorrect: false
+  Include:
+    - "app/models/**/*.rb"
+  VersionAdded: "<<next>>"
+
 Platanus/NoRenderJson:
   Description: "Prefer usage of `respond_with` instead of `render json:` to take advantage of `ApiResponder` and `serializers`"
   Enabled: true

--- a/lib/rubocop/cop/platanus/no_enumerize.rb
+++ b/lib/rubocop/cop/platanus/no_enumerize.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Platanus
+      # Prefer usage of Rails `enum` instead of `Enumerize`
+      #
+      # @safety
+      #   This cop's autocorrection will remove any lines using `extend Enumerize`
+      #   and `enumerize :foo, in: [:bar, :baz]` within a file in app/models.
+      #   There might be a case where using `enumerize` might be the intended behavior.
+      #
+      # @example
+      #   # bad
+      #   class Foo
+      #     extend Enumerize
+      #     enumerize :bar, in: [:foo, :bar]
+      #   end
+      #
+      #   # good
+      #   class Foo
+      #     enum bar: { foo: 0, bar: 1 }
+      #   end
+      #
+      class NoEnumerize < Base
+        extend AutoCorrector
+        MSG = 'Use Rails `enum` instead of `enumerize`.'
+
+        # Detect if class extends `Enumerize`
+        def_node_matcher :extend_enumerize?, <<~PATTERN
+          (send nil? :extend (const nil? :Enumerize) ...)
+        PATTERN
+
+        # Returns the name and `in:` arguments of the enumerize call
+        def_node_matcher :get_enumerize_args, <<~PATTERN
+          (send nil? :enumerize (sym $_) (
+            hash
+            <
+              (pair (sym :in) (array $...))
+              ...
+            >
+          ))
+        PATTERN
+
+        def on_send(node)
+          on_extend_enumerize(node)
+          on_enumerize(node)
+        end
+
+        private
+
+        # Detects if class extends `Enumerize`
+        def on_extend_enumerize(node)
+          return unless extend_enumerize?(node)
+
+          add_offense(node) do |corrector|
+            corrector.remove(node)
+          end
+        end
+
+        # Detects if class uses `enumerize`. If so, it corrects the code.
+        def on_enumerize(node)
+          enumerize_args = get_enumerize_args(node)
+          return unless enumerize_args
+
+          name, args = enumerize_args
+          args = args.map(&:value)
+
+          add_offense(node) do |corrector|
+            corrector.replace(node, enumerize_correction(name, args))
+          end
+        end
+
+        # Returns the corrected code for `enumerize`
+        def enumerize_correction(name, args)
+          args_string = args.map.with_index do |arg, i|
+            "#{arg}: #{i}"
+          end.join(', ')
+
+          "enum #{name}: { #{args_string} }"
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/platanus_cops.rb
+++ b/lib/rubocop/cop/platanus_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'platanus/no_command'
+require_relative 'platanus/no_enumerize'
 require_relative 'platanus/no_render_json'
 require_relative 'platanus/pundit_in_application_controller'

--- a/spec/rubocop/cop/platanus/no_enumerize_spec.rb
+++ b/spec/rubocop/cop/platanus/no_enumerize_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Platanus::NoEnumerize, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using `enumerize`' do
+    expect_offense <<~RUBY
+      class Foo
+        extend Enumerize
+        ^^^^^^^^^^^^^^^^ Use Rails `enum` instead of `enumerize`.
+
+        enumerize :bar, in: [:foo, :bar]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Rails `enum` instead of `enumerize`.
+      end
+    RUBY
+
+    expect_correction <<~RUBY
+      class Foo
+      #{'  '}
+
+        enum bar: { foo: 0, bar: 1 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `enumerize` with more hash parameters' do
+    expect_offense <<~RUBY
+      class Foo
+        extend Enumerize
+        ^^^^^^^^^^^^^^^^ Use Rails `enum` instead of `enumerize`.
+
+        enumerize :bar, in: [:foo, :bar], default: :foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Rails `enum` instead of `enumerize`.
+      end
+    RUBY
+
+    expect_correction <<~RUBY
+      class Foo
+      #{'  '}
+
+        enum bar: { foo: 0, bar: 1 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using `enumerize` with hash parameters in any order' do
+    expect_offense <<~RUBY
+      class Foo
+        extend Enumerize
+        ^^^^^^^^^^^^^^^^ Use Rails `enum` instead of `enumerize`.
+
+        enumerize :bar, default: :foo, in: [:foo, :bar]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Rails `enum` instead of `enumerize`.
+      end
+    RUBY
+
+    expect_correction <<~RUBY
+      class Foo
+      #{'  '}
+
+        enum bar: { foo: 0, bar: 1 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using Rails `enum`' do
+    expect_no_offenses <<~RUBY
+      class Foo
+        enum bar: [:foo, :bar]
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
# Contexto

En Platanus todo el tiempo estamos cambiando herramientas, mejorando nuestras prácticas, etc. Esto ocasiona que los proyectos más viejos no reflejen nuestras últimas decisiones respecto de x temas. Para mantener cierto orden en el código, estamos utilizando [Rubocop](https://github.com/rubocop/rubocop). Esta gema define cientos de reglas de estilo que nos permite escribir código similar/entendible. La idea es crear reglas custom para impulsar decisiones que tomemos desde calidad dev.

Actualmente en los proyectos usamos [Rails enum](https://api.rubyonrails.org/v5.1/classes/ActiveRecord/Enum.html). Antes usábamos [Enumerize](https://github.com/brainspec/enumerize).

# Que se esta haciendo

- Se crea una regla que muestra un warning cuando se usa `enumerize`.
- Se crea un autocorrector que te cambia el uso de `enumerize` a `enum`.
    - El autocorrector inicialmente se marca como **unsafe**. Para usarlo se tiene que correr rubocop con `-A` en vez de `-a`.


![Animation](https://user-images.githubusercontent.com/30664457/169894749-9fbf79a1-58fb-451b-87cb-fcce7b1b54ec.gif)

