### PR TITLE
chore(): restrict cops to run in specific directories

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,14 +3,20 @@
 Platanus/NoCommand:
   Description: "Prefer usage of `ActiveJob` instead of `PowerTypes::Command`"
   Enabled: true
+  Include:
+    - "app/commands/**/*.rb"
   VersionAdded: "<<next>>"
 
 Platanus/NoRenderJson:
   Description: "Prefer usage of `respond_with` instead of `render json:` to take advantage of `ApiResponder` and `serializers`"
   Enabled: true
+  Include:
+    - "app/controllers/**/*.rb"
   VersionAdded: "<<next>>"
 
 Platanus/PunditInApplicationController:
   Description: "`Pundit` should be included only in the `Application Controller`"
   Enabled: true
+  Include:
+    - "app/controllers/**/*.rb"
   VersionAdded: "0.1.0"


### PR DESCRIPTION
# Contexto

Se habian creado cops de RuboCop para imponer las reglas de estilo de Platanus. El problema es que estas reglas corrían en todos los archivos, cuando en realidad solo hace sentido para ciertos archivos.

# Que se está haciendo

Se configuran las reglas para solo correrlas en los directorios donde hacen sentido.