### PR TITLE
fix(): fixed error on NoRenderJson when variable was undefined

### DIFF
--- a/lib/rubocop/cop/platanus/no_render_json.rb
+++ b/lib/rubocop/cop/platanus/no_render_json.rb
@@ -96,8 +96,6 @@ module RuboCop
           hash_node = respond_with(node)
           return true if is_hash?(hash_node)
 
-          return false unless hash_node.variable?
-
           var_name = var_name(hash_node)
           return false if var_name.nil?
 

--- a/spec/rubocop/cop/platanus/no_render_json_spec.rb
+++ b/spec/rubocop/cop/platanus/no_render_json_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe RuboCop::Cop::Platanus::NoRenderJson, :config do
       respond_with(my_resource)
     RUBY
   end
+
+  it 'does not register an offense when using `respond_with` with an undefined variable' do
+    expect_no_offenses <<~RUBY
+      def foo
+        respond_with MyModel.first
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
# Contexto

Se habia creado un cop NoRenderJson que entregaba un warning al usar `render_json` o `respond_with { some: 'hash' }`.

El problema es que se cae cuando se usa `respond_with my_variable`, y `my_variable` no esta definida. Esto ocurria por el uso de `.variable?`, que no esta definido para cualquier nodo.

# Que se esta haciendo

Es suficiente hacer el match sobre el nodo para saber si es una variable, por lo que se elimina la linea.
