### PR TITLE
Feat/no flash in api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Features
 
+* Add cop Platanus/NoFlashInApi
 * Add cop Platanus/NoRenderJson
 * Add cop Platanus/PunditInApplicationController
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,6 +7,14 @@ Platanus/NoCommand:
     - "app/commands/**/*.rb"
   VersionAdded: "<<next>>"
 
+Platanus/NoFlashInApi:
+  Description: "Don't use `flash` in api controllers."
+  Enabled: true
+  Include:
+    - "app/controllers/api/**/*.rb"
+  SafeAutoCorrect: false
+  VersionAdded: "<<next>>"
+
 Platanus/NoRenderJson:
   Description: "Prefer usage of `respond_with` instead of `render json:` to take advantage of `ApiResponder` and `serializers`"
   Enabled: true

--- a/lib/rubocop/cop/platanus/no_flash_in_api.rb
+++ b/lib/rubocop/cop/platanus/no_flash_in_api.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Platanus
+      # Flash shouldn't be used in API controllers.
+      #
+      # @safety
+      #   Auto correction will delete any lines using `flash[:type] = 'foo'`. There might be cases
+      #   where using flash might be the intended behavior.
+      #
+      # @example
+      #
+      #   # bad
+      #   class Api::Internal::ResourcesController < Api::Internal::BaseController
+      #     def show
+      #       flash[:notice] = 'Foo'
+      #       ...
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Api::Internal::ResourcesController < Api::Internal::BaseController
+      #     def show
+      #       ...
+      #     end
+      #   end
+      #
+      class NoFlashInApi < Base
+        extend AutoCorrector
+
+        MSG = "Don't use `flash` in API controllers."
+
+        def_node_matcher :flash?, <<~PATTERN
+          (send (send nil? :flash) :[]= ...)
+        PATTERN
+
+        def on_send(node)
+          return unless flash?(node)
+
+          add_offense(node) do |corrector|
+            corrector.remove(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/platanus_cops.rb
+++ b/lib/rubocop/cop/platanus_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'platanus/no_command'
+require_relative 'platanus/no_flash_in_api'
 require_relative 'platanus/no_render_json'
 require_relative 'platanus/pundit_in_application_controller'

--- a/spec/rubocop/cop/platanus/no_flash_in_api_spec.rb
+++ b/spec/rubocop/cop/platanus/no_flash_in_api_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Platanus::NoFlashInApi, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using `flash`' do
+    expect_offense <<~RUBY
+      class Foo
+        def bar
+          flash[:notice] = 'Foo'
+          ^^^^^^^^^^^^^^^^^^^^^^ Don't use `flash` in API controllers.
+          flash[:danger] = 'Bar'
+          ^^^^^^^^^^^^^^^^^^^^^^ Don't use `flash` in API controllers.
+          flash['success'] = 'Baz'
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Don't use `flash` in API controllers.
+          redirect_to root_path
+        end
+      end
+    RUBY
+
+    expect_correction <<~RUBY
+      class Foo
+        def bar
+        #{'  '}
+        #{'  '}
+        #{'  '}
+          redirect_to root_path
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when not using `flash`' do
+    expect_no_offenses <<~RUBY
+      class Foo
+        def bar
+          redirect_to root_path
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
# Contexto

En algunos controllers de api se está usando [flash](https://guides.rubyonrails.org/action_controller_overview.html#the-flash). Esto no tiene sentido en APIs.

# Que se esta haciendo

- Se crea un cop que entrega un warning cuando se detecta el uso de `flash[:foo] = "bar"` en algun archivo de `app/controlers/api`.
- Se crea un autocorrector que te elimina la linea que usa `flash`.
    - El autocorrector inicialmente se marca como **unsafe**. Para usarlo se tiene que correr rubocop con `-A` en vez de `-a`.

![Animation](https://user-images.githubusercontent.com/30664457/169909636-d9f874ae-cd6a-4feb-b623-8a307ca8cb01.gif)

